### PR TITLE
Added dark mode support for password field

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -373,7 +373,11 @@ FeaturedImageViewControllerDelegate>
     [self.tableView reloadData];
 }
 
-
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+    [self reloadData];
+}
 #pragma mark - TextField Delegate Methods
 
 - (BOOL)textFieldShouldEndEditing:(UITextField *)textField
@@ -702,6 +706,7 @@ FeaturedImageViewControllerDelegate>
     textCell.textField.placeholder = NSLocalizedString(@"Enter a password", @"");
     textCell.textField.clearButtonMode = UITextFieldViewModeWhileEditing;
     textCell.textField.secureTextEntry = YES;
+    textCell.textField.textColor = self.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark ? UIColor.whiteColor : UIColor.blackColor;
     
     textCell.tag = PostSettingsRowPassword;
     


### PR DESCRIPTION

![Simulator Screen Shot - iPod touch (7th generation) - 2021-01-27 at 14 58 25](https://user-images.githubusercontent.com/26477672/105932186-667edc80-60b1-11eb-808f-f3578ee97cca.png)
![Simulator Screen Shot - iPod touch (7th generation) - 2021-01-27 at 14 58 16](https://user-images.githubusercontent.com/26477672/105932191-6b439080-60b1-11eb-8398-c40cf2dd23b1.png)

An attempt to fix the bug: https://github.com/wordpress-mobile/WordPress-iOS/issues/15705

Fixes #

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
