### PR TITLE
Fix HTML attributes render in tag name

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -127,7 +127,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         ReaderInterestsStyleGuide.applyCompactCellLabelStyle(label: cell.label)
 
         cell.layer.cornerRadius = Constants.cellCornerRadius
-        cell.label.text = title
+        cell.label.text = NSAttributedString.attributedStringWithHTML(title, attributes: nil).string
         cell.label.accessibilityHint = Strings.accessbilityHint
         cell.label.accessibilityTraits = .button
     }


### PR DESCRIPTION
The ReaderInterestsCollectionViewCell was rendering the tag as plain text. This created problems when certain tags had HTML characters.

Now the tag name is first transformed into an attributed string with HTML. After, it is transformed into a string again, so the design (font, text color) is not impacted.

An attempt to fix: [wordpress-mobile#14913](https://github.com/wordpress-mobile/WordPress-iOS/issues/14913)
Fixes #

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
